### PR TITLE
feat/authz-casbin-base

### DIFF
--- a/CasbinModel/rbac_with_domains.conf
+++ b/CasbinModel/rbac_with_domains.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, dom, obj, act
+
+[policy_definition]
+p = sub, dom, obj, act
+
+[role_definition]
+g = _, _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub, r.dom) && r.dom == p.dom && r.obj == p.obj && r.act == p.act

--- a/CasbinPolicy/policy.csv
+++ b/CasbinPolicy/policy.csv
@@ -1,0 +1,21 @@
+p, HRAdmin, line-1, api.leave, read
+p, HRAdmin, line-1, api.leave, approve
+p, HRAdmin, line-2, api.leave, read
+p, HRAdmin, line-2, api.leave, approve
+p, HRManager, line-1, api.leave, read
+p, HRManager, line-1, api.leave, approve
+p, HRManager, line-2, api.leave, read
+p, HRManager, line-2, api.leave, approve
+p, HRUser, line-1, api.leave, read
+p, HRUser, line-2, api.leave, read
+p, Auditor, line-1, api.leave, read
+p, Auditor, line-2, api.leave, read
+
+g, alice, HRAdmin, line-1
+g, alice, HRAdmin, line-2
+g, bob, HRManager, line-1
+g, bob, HRManager, line-2
+g, cathy, HRUser, line-1
+g, cathy, HRUser, line-2
+g, dave, Auditor, line-1
+g, dave, Auditor, line-2

--- a/HRAuthorization.Api/HRAuthorization.Api.csproj
+++ b/HRAuthorization.Api/HRAuthorization.Api.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Casbin.NET" Version="1.39.0" />
+    <PackageReference Include="Casbin.AspNetCore" Version="1.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="../CasbinModel/rbac_with_domains.conf" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../CasbinPolicy/policy.csv" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/HRAuthorization.Api/Program.cs
+++ b/HRAuthorization.Api/Program.cs
@@ -1,0 +1,46 @@
+using Casbin;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = builder.Configuration["Jwt:Authority"];
+        options.Audience = builder.Configuration["Jwt:Audience"];
+    });
+
+var modelPath = Path.Combine(builder.Environment.ContentRootPath, "..", "CasbinModel", "rbac_with_domains.conf");
+var policyPath = Path.Combine(builder.Environment.ContentRootPath, "..", "CasbinPolicy", "policy.csv");
+
+builder.Services.AddSingleton<IEnforcer>(_ => new Enforcer(modelPath, policyPath));
+
+builder.Services.AddAuthorization();
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapGet("/authz/check", async (HttpContext ctx, IEnforcer enforcer, string dom, string obj, string act) =>
+{
+    var sub = ctx.User.Identity?.Name ?? string.Empty;
+    var allowed = await enforcer.EnforceAsync(sub, dom, obj, act);
+    return allowed ? Results.NoContent() : Results.StatusCode(StatusCodes.Status403Forbidden);
+}).RequireAuthorization();
+
+app.MapGet("/api/leave/{id}", async (HttpContext ctx, IEnforcer enforcer, string dom, string id) =>
+{
+    var sub = ctx.User.Identity?.Name ?? string.Empty;
+    var allowed = await enforcer.EnforceAsync(sub, dom, "api.leave", "read");
+    return allowed ? Results.Ok(new { Id = id }) : Results.StatusCode(StatusCodes.Status403Forbidden);
+}).RequireAuthorization();
+
+app.MapPost("/api/leave/{id}/approve", async (HttpContext ctx, IEnforcer enforcer, string dom, string id) =>
+{
+    var sub = ctx.User.Identity?.Name ?? string.Empty;
+    var allowed = await enforcer.EnforceAsync(sub, dom, "api.leave", "approve");
+    return allowed ? Results.NoContent() : Results.StatusCode(StatusCodes.Status403Forbidden);
+}).RequireAuthorization();
+
+app.Run();

--- a/HRAuthorization.Tests/AuthorizationTests.cs
+++ b/HRAuthorization.Tests/AuthorizationTests.cs
@@ -1,0 +1,53 @@
+using Casbin;
+using Xunit;
+
+namespace HRAuthorization.Tests;
+
+public class AuthorizationTests
+{
+    private readonly Enforcer _enforcer;
+
+    public AuthorizationTests()
+    {
+        var root = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..");
+        var model = Path.Combine(root, "CasbinModel", "rbac_with_domains.conf");
+        var policy = Path.Combine(root, "CasbinPolicy", "policy.csv");
+        _enforcer = new Enforcer(model, policy);
+    }
+
+    [Theory]
+    [InlineData("alice", "line-1")]
+    [InlineData("alice", "line-2")]
+    public async Task HRAdmin_Can_Read_And_Approve(string user, string dom)
+    {
+        Assert.True(await _enforcer.EnforceAsync(user, dom, "api.leave", "read"));
+        Assert.True(await _enforcer.EnforceAsync(user, dom, "api.leave", "approve"));
+    }
+
+    [Theory]
+    [InlineData("bob", "line-1")]
+    [InlineData("bob", "line-2")]
+    public async Task HRManager_Can_Read_And_Approve(string user, string dom)
+    {
+        Assert.True(await _enforcer.EnforceAsync(user, dom, "api.leave", "read"));
+        Assert.True(await _enforcer.EnforceAsync(user, dom, "api.leave", "approve"));
+    }
+
+    [Theory]
+    [InlineData("cathy", "line-1")]
+    [InlineData("cathy", "line-2")]
+    public async Task HRUser_Can_Read_But_Not_Approve(string user, string dom)
+    {
+        Assert.True(await _enforcer.EnforceAsync(user, dom, "api.leave", "read"));
+        Assert.False(await _enforcer.EnforceAsync(user, dom, "api.leave", "approve"));
+    }
+
+    [Theory]
+    [InlineData("dave", "line-1")]
+    [InlineData("dave", "line-2")]
+    public async Task Auditor_Can_Read_But_Not_Approve(string user, string dom)
+    {
+        Assert.True(await _enforcer.EnforceAsync(user, dom, "api.leave", "read"));
+        Assert.False(await _enforcer.EnforceAsync(user, dom, "api.leave", "approve"));
+    }
+}

--- a/HRAuthorization.Tests/HRAuthorization.Tests.csproj
+++ b/HRAuthorization.Tests/HRAuthorization.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="Casbin.NET" Version="1.39.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../HRAuthorization.Api/HRAuthorization.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# HR Authorization Proof of Concept
+
+This repository demonstrates separating authentication (AuthN) and authorization (AuthZ) in an ASP.NET Core **.NET 6** API using [Casbin](https://casbin.org/).
+
+## Architecture
+
+* **Authentication (AuthN):**
+  * JWT Bearer tokens are validated using the configured `Authority` and `Audience` in `Program.cs`.
+  * Successful validation establishes the caller's identity (`sub`).
+* **Authorization (AuthZ):**
+  * [Casbin.NET](https://github.com/casbin-net) enforces domain based RBAC rules.
+  * The model is defined in `CasbinModel/rbac_with_domains.conf` and policies in `CasbinPolicy/policy.csv`.
+  * Endpoints consult the `IEnforcer` to decide whether a request is allowed.
+
+## Endpoints
+
+* `GET /authz/check?dom=&obj=&act=` – returns **204** when access is allowed and **403** otherwise.
+* `GET /api/leave/{id}?dom=` – requires `(dom, api.leave, read)`.
+* `POST /api/leave/{id}/approve?dom=` – requires `(dom, api.leave, approve)`.
+
+## Running
+
+1. Install the .NET 6 SDK.
+2. Restore dependencies:
+   ```bash
+   dotnet restore
+   ```
+3. Run the API:
+   ```bash
+   dotnet run --project HRAuthorization.Api
+   ```
+4. Execute tests:
+   ```bash
+   dotnet test
+   ```
+
+The Casbin model and policy files can be edited to experiment with different authorization rules.


### PR DESCRIPTION
## Summary
- set up .NET 6 API with JWT validation and Casbin-based RBAC
- add domain-aware Casbin model and policies for HR roles
- provide xUnit tests and documentation on authN/authZ separation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d0c15820832bb414f9f4ac2975c6