### PR TITLE
Add weather forecast service and controller

### DIFF
--- a/HRAuthorization.Api/Controllers/WeatherForecastController.cs
+++ b/HRAuthorization.Api/Controllers/WeatherForecastController.cs
@@ -1,0 +1,18 @@
+using HRAuthorization.Api.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HRAuthorization.Api.Controllers;
+
+[ApiController]
+[Route("weatherforecast")]
+public class WeatherForecastController : ControllerBase
+{
+    private readonly IWeatherService _service;
+
+    public WeatherForecastController(IWeatherService service)
+        => _service = service;
+
+    [HttpGet]
+    public IEnumerable<WeatherForecast> Get()
+        => _service.GetForecast();
+}

--- a/HRAuthorization.Api/Services/IWeatherService.cs
+++ b/HRAuthorization.Api/Services/IWeatherService.cs
@@ -1,0 +1,6 @@
+namespace HRAuthorization.Api.Services;
+
+public interface IWeatherService
+{
+    IEnumerable<WeatherForecast> GetForecast();
+}

--- a/HRAuthorization.Api/Services/WeatherService.cs
+++ b/HRAuthorization.Api/Services/WeatherService.cs
@@ -1,0 +1,22 @@
+
+namespace HRAuthorization.Api.Services;
+
+public class WeatherService : IWeatherService
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild",
+        "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    public IEnumerable<WeatherForecast> GetForecast()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+        {
+            Date = DateTime.Now.AddDays(index),
+            TemperatureC = Random.Shared.Next(-20, 55),
+            Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+        })
+        .ToArray();
+    }
+}

--- a/HRAuthorization.Api/WeatherForecast.cs
+++ b/HRAuthorization.Api/WeatherForecast.cs
@@ -1,0 +1,12 @@
+namespace HRAuthorization.Api;
+
+public class WeatherForecast
+{
+    public DateTime Date { get; set; }
+
+    public int TemperatureC { get; set; }
+
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+    public string? Summary { get; set; }
+}


### PR DESCRIPTION
## Summary
- Extract weather forecast logic into `WeatherService`
- Register service and use MVC controller
- Replace minimal endpoints with `MapControllers`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d9a0458c832ba617a8ca8d907e2d