### PR TITLE
feat(api): add authorization controller

### DIFF
--- a/HRAuthorization.Api/Controllers/AuthzController.cs
+++ b/HRAuthorization.Api/Controllers/AuthzController.cs
@@ -1,0 +1,26 @@
+using Casbin;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HRAuthorization.Api.Controllers;
+
+[ApiController]
+[Route("authz")]
+public class AuthzController : ControllerBase
+{
+    private readonly IEnforcer _enforcer;
+
+    public AuthzController(IEnforcer enforcer) => _enforcer = enforcer;
+
+    [HttpGet("check")]
+    public async Task<IActionResult> Check([FromQuery] string dom, [FromQuery] string obj, [FromQuery] string act)
+    {
+        var user = User.Identity?.Name ?? string.Empty;
+
+        if (await _enforcer.EnforceAsync(user, dom, obj, act))
+        {
+            return NoContent();
+        }
+
+        return Forbid();
+    }
+}


### PR DESCRIPTION
## Summary
- add AuthzController to expose /authz/check endpoint using Casbin to enforce permissions

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e372ca30832bbcb385b868dcf196