### PR TITLE
Add leave controller with Casbin authorization

### DIFF
--- a/HRAuthorization.Api/Controllers/LeaveController.cs
+++ b/HRAuthorization.Api/Controllers/LeaveController.cs
@@ -1,0 +1,40 @@
+using Casbin;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HRAuthorization.Api.Controllers;
+
+[ApiController]
+[Route("api/leave")]
+public class LeaveController : ControllerBase
+{
+    private readonly IEnforcer _enforcer;
+
+    public LeaveController(IEnforcer enforcer) => _enforcer = enforcer;
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> Get(string id, [FromQuery] string dom)
+    {
+        var user = User.Identity?.Name ?? string.Empty;
+
+        if (await _enforcer.EnforceAsync(user, dom, "api.leave", "read"))
+        {
+            return Ok();
+        }
+
+        return Forbid();
+    }
+
+    [HttpPost("{id}/approve")]
+    public async Task<IActionResult> Approve(string id, [FromQuery] string dom)
+    {
+        var user = User.Identity?.Name ?? string.Empty;
+
+        if (await _enforcer.EnforceAsync(user, dom, "api.leave", "approve"))
+        {
+            return Ok();
+        }
+
+        return Forbid();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add leave controller secured with Casbin enforcements

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e4e9e138832bbb544a3167588c46